### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,8 @@ The implementation is functional right now, can coin up and start game, known pr
 * Game EPROM is implemented as RAM so game settings are lost on power off.
 
 ## MiSTer Install
+On a [MiSTer](https://github.com/MiSTer-devel/Main_MiSTer/wiki) FPGA board, a [SDRAM expansion](https://github.com/MiSTer-devel/Main_MiSTer/wiki/SDRAM-Board) daughterboard is needed to play Gauntlet II and Vindicators part II.
+
 This repository follows the standard folder structure for distributing MiSTer files.
 
 ROMs are not included so in order to use this arcade, you need to provide the correct game ROM.  


### PR DESCRIPTION
As per this issue, https://github.com/d18c7db/Gauntlet_FPGA/issues/13#issuecomment-709853543, the MiSTer requires an SDRAM expansion to run Gauntlet II and Vindicators part 2. It has also come up on the [MiSTer forums](https://misterfpga.org/viewtopic.php?p=16026#p16026). Updating the `readme.md` to reflect this.